### PR TITLE
Add default english dictionary to the croatian FT configuration.

### DIFF
--- a/10/add_croatian_language_pack.sh
+++ b/10/add_croatian_language_pack.sh
@@ -15,7 +15,7 @@
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian
@@ -39,7 +39,7 @@ EOSQL
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian

--- a/11/add_croatian_language_pack.sh
+++ b/11/add_croatian_language_pack.sh
@@ -15,7 +15,7 @@
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian
@@ -39,7 +39,7 @@ EOSQL
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian

--- a/9.3/add_croatian_language_pack.sh
+++ b/9.3/add_croatian_language_pack.sh
@@ -15,7 +15,7 @@
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian
@@ -39,7 +39,7 @@ EOSQL
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian

--- a/9.4/add_croatian_language_pack.sh
+++ b/9.4/add_croatian_language_pack.sh
@@ -15,7 +15,7 @@
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian
@@ -39,7 +39,7 @@ EOSQL
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian

--- a/9.5/add_croatian_language_pack.sh
+++ b/9.5/add_croatian_language_pack.sh
@@ -15,7 +15,7 @@
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian
@@ -39,7 +39,7 @@ EOSQL
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian

--- a/9.6/add_croatian_language_pack.sh
+++ b/9.6/add_croatian_language_pack.sh
@@ -15,7 +15,7 @@
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian
@@ -39,7 +39,7 @@ EOSQL
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian

--- a/add_croatian_language_pack.sh
+++ b/add_croatian_language_pack.sh
@@ -15,7 +15,7 @@
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian
@@ -39,7 +39,7 @@ EOSQL
     ALTER TEXT SEARCH CONFIGURATION croatian
         ALTER MAPPING FOR asciiword, asciihword, hword_asciipart,
                         word, hword, hword_part
-        WITH croatian_ispell;
+        WITH croatian_ispell, english_stem;
 
     -- Remove fulltext search mappings for special types
     ALTER TEXT SEARCH CONFIGURATION croatian


### PR DESCRIPTION
Add the default Postgres `english_stem` dictionary to the croatian language search configuration in order to improve search results for non-croatian terms.